### PR TITLE
:sparkles: Make filtered span classification general to text and token classification

### DIFF
--- a/caikit_nlp/data_model/classification.py
+++ b/caikit_nlp/data_model/classification.py
@@ -51,3 +51,10 @@ class TokenClassification(DataObjectBase):
 @caikit.core.dataobject(package="caikit_data_model.caikit_nlp")
 class TokenClassificationResult(DataObjectBase):
     results: List[TokenClassification]
+
+
+# Streaming result that indicates up to where in stream is processed
+@caikit.core.dataobject(package="caikit_data_model.caikit_nlp")
+class StreamingTokenClassificationResult(TokenClassificationResult):
+    # Result index up to which text is processed
+    processed_index: int

--- a/caikit_nlp/modules/text_classification/sequence_classification.py
+++ b/caikit_nlp/modules/text_classification/sequence_classification.py
@@ -223,8 +223,9 @@ class SequenceClassification(ModuleBase):
         error.type_check("<NLP40517898E>", Dict, scores_dict=scores_dict)
         classification_list = []
         for label, score_array in scores_dict.items():
+            # NOTE: labels are expected to be str, especially for config
             classification_list.append(
-                Classification(label=label, score=score_array[text_idx])
+                Classification(label=str(label), score=score_array[text_idx])
             )
         return ClassificationResult(results=classification_list)
 

--- a/caikit_nlp/modules/text_classification/sequence_classification.py
+++ b/caikit_nlp/modules/text_classification/sequence_classification.py
@@ -65,7 +65,8 @@ class SequenceClassification(ModuleBase):
     ################################## API functions #############################################
 
     def run(self, text: str) -> ClassificationResult:
-        """Run the sequence classification, truncates sequences too long for model
+        """Run the sequence classification.
+            NOTE: This will truncate sequences that are too long for model
 
         Args:
             text: str

--- a/caikit_nlp/modules/text_classification/sequence_classification.py
+++ b/caikit_nlp/modules/text_classification/sequence_classification.py
@@ -49,7 +49,6 @@ class SequenceClassification(ModuleBase):
     def __init__(
         self,
         resource: HFAutoSequenceClassifier,
-        device: Union[str, int, None],
     ):
         super().__init__()
         error.type_check(
@@ -60,7 +59,6 @@ class SequenceClassification(ModuleBase):
         self.resource = resource
         self.tokenizer = resource.tokenizer
         self.model = resource.model
-        self.device = device
 
     ################################## API functions #############################################
 
@@ -132,8 +130,7 @@ class SequenceClassification(ModuleBase):
         """
         loader = ModuleLoader(model_path)
         resource = loader.load_module("sequence_classifier")
-        device = SequenceClassification._get_device()
-        return cls(resource=resource, device=device)
+        return cls(resource=resource)
 
     @classmethod
     def bootstrap(cls, base_model_path: str) -> "SequenceClassification":
@@ -148,10 +145,8 @@ class SequenceClassification(ModuleBase):
         resource = HFAutoSequenceClassifier.bootstrap(
             model_name=base_model_path, tokenizer_name=base_model_path
         )
-        device = SequenceClassification._get_device()
         return cls(
             resource=resource,
-            device=device,
         )
 
     ################################## Private Functions #########################################
@@ -168,6 +163,8 @@ class SequenceClassification(ModuleBase):
                 Dict with key label, and values as the array of scores,
                 each corresponding to text(s)
         """
+        # NOTE: no explicit GPU support at this time
+
         # Apply tokenizer
         tokenized_text = self.tokenizer(
             text,
@@ -175,11 +172,8 @@ class SequenceClassification(ModuleBase):
             truncation=True,
             return_tensors="pt",  # PyTorch
         )
-        # NOTE: no simple/efficient way to detect whether truncation
-        # happened since padding also occurs, and this can be applied on
-        # a batch of strings.
-        if self.device == "cuda":
-            tokenized_text = tokenized_text.to(self.device)
+        # NOTE: no truncation warning given at this time
+        # difficult to detect if truncation happened since padding also occurs
         with torch.no_grad():
             logits = self.model(**tokenized_text).logits
 
@@ -191,13 +185,15 @@ class SequenceClassification(ModuleBase):
 
         softmax = torch.nn.Softmax(dim=1)
         raw_scores = softmax(logits)
-        if self.device == "cuda":
-            scores = raw_scores.cpu().numpy()
-        else:
-            scores = raw_scores.numpy()
+        scores = raw_scores.numpy()
+        num_labels = self.model.num_labels
+        log.error(
+            "<NLP33929938E>",
+            scores.shape == (len(text), num_labels),
+            "model logits expected to be of shape (num_texts, num_labels)",
+        )
 
         scores_dict = {}
-        num_labels = self.model.num_labels
         for label_idx in range(num_labels):
             if self.model.config.id2label:
                 label = self.model.config.id2label[label_idx]
@@ -229,18 +225,3 @@ class SequenceClassification(ModuleBase):
                 Classification(label=str(label), score=score_array[text_idx])
             )
         return ClassificationResult(results=classification_list)
-
-    # NOTE: similar to prompt tuning but no user override, could consolidate eventually
-    @staticmethod
-    def _get_device() -> Union[str, int, None]:
-        """Get the device which we expect to run our models on. Defaults to GPU
-        if one is available, otherwise falls back to None (cpu).
-
-        Returns:
-            Union[str, int, None]
-                Device string that we should move our models / tensors .to() at training
-                and inference time.
-        """
-        device = "cuda" if torch.cuda.is_available() else None
-        log.debug("Using device: %s", device)
-        return device

--- a/caikit_nlp/modules/text_classification/sequence_classification.py
+++ b/caikit_nlp/modules/text_classification/sequence_classification.py
@@ -187,9 +187,12 @@ class SequenceClassification(ModuleBase):
         raw_scores = softmax(logits)
         scores = raw_scores.numpy()
         num_labels = self.model.num_labels
-        log.error(
+        num_texts = 1  # str
+        if isinstance(text, List):
+            num_texts = len(text)
+        error.value_check(
             "<NLP33929938E>",
-            scores.shape == (len(text), num_labels),
+            scores.shape == (num_texts, num_labels),
             "model logits expected to be of shape (num_texts, num_labels)",
         )
 

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -33,11 +33,14 @@ import alog
 
 # Local
 from ...data_model import TokenClassification, TokenClassificationResult
-from ..text_classification import SequenceClassification
+from ..text_classification.text_classification_task import TextClassificationTask
 from .token_classification_task import TokenClassificationTask
 
 log = alog.use_channel("FILT_SPAN")
 error = error_handler.get(log)
+
+# Tasks allowed for the module to be provided for classifier
+ALLOWED_TASKS = [TextClassificationTask, TokenClassificationTask]
 
 
 @module(
@@ -54,7 +57,7 @@ class FilteredSpanClassification(ModuleBase):
         self,
         lang: str,
         span_splitter: ModuleBase,
-        sequence_classifier: SequenceClassification,
+        classifier: ModuleBase,
         default_threshold: float,
         labels_to_output: List[str] = None,
     ):
@@ -66,8 +69,8 @@ class FilteredSpanClassification(ModuleBase):
                 2 letter language code
             span_splitter: ModuleBase
                 Span splitter that returns List[Span]
-            sequence_classifier: SequenceClassification
-                Sequence classification model
+            classifier: ModuleBase
+                Classification model instance returning Classification or TokenClassification output on .run
             default_threshold: float
                 Default threshold for scores
             labels_to_output: List[str]
@@ -78,18 +81,25 @@ class FilteredSpanClassification(ModuleBase):
         error.type_check("<NLP79642537E>", ModuleBase, span_splitter=span_splitter)
         error.type_check(
             "<NLP35742128E>",
-            SequenceClassification,
-            sequence_classifier=sequence_classifier,
+            ModuleBase,
+            classifier=classifier,
         )
         error.type_check("<NLP63802045E>", float, default_threshold=default_threshold)
         error.type_check_all(
             "<NLP71653678E>", str, allow_none=True, labels_to_output=labels_to_output
         )
+        classification_task = classifier.TASK_CLASS
+        if classification_task not in ALLOWED_TASKS:
+            log.error(
+                "<NLP92989564E>",
+                f"classifier does not implement one of required tasks: {ALLOWED_TASKS}",
+            )
         self.lang = lang
         self.span_splitter = span_splitter
-        self.sequence_classifier = sequence_classifier
+        self.classifier = classifier
         self.default_threshold = default_threshold
         self.labels_to_output = labels_to_output
+        self.classification_task = classification_task
 
     ################################## API functions #############################################
 
@@ -111,27 +121,35 @@ class FilteredSpanClassification(ModuleBase):
         if threshold is None:
             threshold = self.default_threshold
         token_classification_results = []
-        # Split document into sentences
-        sentence_span_list = self.span_splitter.run(text)
-        # Run each sentence through the classifier and determine based
+        if self.classification_task == TextClassificationTask:
+            # Split document into spans
+            span_list = self.span_splitter.run(text)
+            text_list = [span.text for span in span_list]
+        else:
+            # TokenClassificationTask classifiers would hold span info
+            # so we do not need to span split again
+            text_list = [text]
+        # Run each span through the classifier and determine based
         # on threshold and labels_to_output what results should be returned
-        text_list = [span.text for span in sentence_span_list]
-        classification_results = self.sequence_classifier.run_batch(text_list)
+        classification_results = self.classifier.run_batch(text_list)
         for idx, classification_result in enumerate(classification_results):
-            # Each classification prediction is list of classifications
+            # Each classification result is list of classifications
             # for that particular text example
             for classification in classification_result.results:
                 # NOTE: labels need to be specified as str for config
-                label = str(classification.label)
+                if self.classification_task == TextClassificationTask:
+                    label = classification.label
+                else:
+                    label = classification.entity
                 if classification.score >= threshold:
                     if not self.labels_to_output or (
                         self.labels_to_output and label in self.labels_to_output
                     ):
-                        sentence_span = sentence_span_list[idx]
+                        span = span_list[idx]
                         token_classification = TokenClassification(
-                            start=sentence_span.start,
-                            end=sentence_span.end,
-                            word=sentence_span.text,
+                            start=span.start,
+                            end=span.end,
+                            word=span.text,
                             entity=label,
                             score=classification.score,
                         )
@@ -152,9 +170,7 @@ class FilteredSpanClassification(ModuleBase):
 
         with module_saver:
             module_saver.save_module(self.span_splitter, "span_split")
-            module_saver.save_module(
-                self.sequence_classifier, "sequence_classification"
-            )
+            module_saver.save_module(self.classifier, "sequence_classification")
             config_options = {
                 "language": self.lang,
                 "default_threshold": self.default_threshold,
@@ -177,10 +193,10 @@ class FilteredSpanClassification(ModuleBase):
         config = ModuleConfig.load(os.path.abspath(model_path))
         loader = ModuleLoader(model_path)
         span_splitter = loader.load_module("span_split")
-        sequence_classifier = loader.load_module("sequence_classification")
+        classifier = loader.load_module("sequence_classification")
         return cls(
             span_splitter=span_splitter,
-            sequence_classifier=sequence_classifier,
+            classifier=classifier,
             lang=config.language,
             default_threshold=config.default_threshold,
             labels_to_output=config.labels_to_output,
@@ -191,7 +207,7 @@ class FilteredSpanClassification(ModuleBase):
         cls,
         lang: str,
         span_splitter: ModuleBase,
-        sequence_classifier: SequenceClassification,
+        classifier: ModuleBase,
         default_threshold: float,
         labels_to_output: List[str] = None,
     ) -> "FilteredSpanClassification":
@@ -202,8 +218,8 @@ class FilteredSpanClassification(ModuleBase):
                 2 letter language code
             span_splitter: ModuleBase
                 Span splitter that returns List[Span]
-            sequence_classifier: SequenceClassification
-                Sequence classification model
+            classifier: ModuleBase
+                Classification model instance returning Classification or TokenClassification output on .run
             default_threshold: float
                 Default threshold for scores
             labels_to_output: List[str]
@@ -213,7 +229,7 @@ class FilteredSpanClassification(ModuleBase):
         return cls(
             lang=lang,
             span_splitter=span_splitter,
-            sequence_classifier=sequence_classifier,
+            classifier=classifier,
             default_threshold=default_threshold,
             labels_to_output=labels_to_output,
         )

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -238,7 +238,7 @@ class FilteredSpanClassification(ModuleBase):
 
         with module_saver:
             module_saver.save_module(self.span_splitter, "span_split")
-            module_saver.save_module(self.classifier, "sequence_classification")
+            module_saver.save_module(self.classifier, "classification")
             config_options = {
                 "language": self.lang,
                 "default_threshold": self.default_threshold,
@@ -261,7 +261,7 @@ class FilteredSpanClassification(ModuleBase):
         config = ModuleConfig.load(os.path.abspath(model_path))
         loader = ModuleLoader(model_path)
         span_splitter = loader.load_module("span_split")
-        classifier = loader.load_module("sequence_classification")
+        classifier = loader.load_module("classification")
         return cls(
             span_splitter=span_splitter,
             classifier=classifier,

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -111,27 +111,26 @@ class FilteredSpanClassification(ModuleBase):
         if threshold is None:
             threshold = self.default_threshold
         token_classification_results = []
-        # Split document into sentences
-        sentence_span_list = self.span_splitter.run(text)
-        # Run each sentence through the classifier and determine based
+        # Split document into spans
+        span_list = self.span_splitter.run(text)
+        # Run each span through the classifier and determine based
         # on threshold and labels_to_output what results should be returned
-        text_list = [span.text for span in sentence_span_list]
+        text_list = [span.text for span in span_list]
         classification_results = self.sequence_classifier.run_batch(text_list)
         for idx, classification_result in enumerate(classification_results):
             # Each classification prediction is list of classifications
             # for that particular text example
             for classification in classification_result.results:
-                # NOTE: labels need to be specified as str for config
-                label = str(classification.label)
+                label = classification.label
                 if classification.score >= threshold:
                     if not self.labels_to_output or (
                         self.labels_to_output and label in self.labels_to_output
                     ):
-                        sentence_span = sentence_span_list[idx]
+                        span = span_list[idx]
                         token_classification = TokenClassification(
-                            start=sentence_span.start,
-                            end=sentence_span.end,
-                            word=sentence_span.text,
+                            start=span.start,
+                            end=span.end,
+                            word=span.text,
                             entity=label,
                             score=classification.score,
                         )

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -70,7 +70,8 @@ class FilteredSpanClassification(ModuleBase):
             span_splitter: ModuleBase
                 Span splitter that returns List[Span]
             classifier: ModuleBase
-                Classification model instance returning Classification or TokenClassification output on .run
+                Classification model instance returning Classification or
+                TokenClassification output on .run
             default_threshold: float
                 Default threshold for scores
             labels_to_output: List[str]
@@ -138,17 +139,23 @@ class FilteredSpanClassification(ModuleBase):
             for classification in classification_result.results:
                 if self.classification_task == TextClassificationTask:
                     label = classification.label
+                    span = span_list[idx]
+                    start = span.start
+                    end = span.end
+                    word = span.text
                 else:
                     label = classification.entity
+                    start = classification.start
+                    end = classification.end
+                    word = classification.word
                 if classification.score >= threshold:
                     if not self.labels_to_output or (
                         self.labels_to_output and label in self.labels_to_output
                     ):
-                        span = span_list[idx]
                         token_classification = TokenClassification(
-                            start=span.start,
-                            end=span.end,
-                            word=span.text,
+                            start=start,
+                            end=end,
+                            word=word,
                             entity=label,
                             score=classification.score,
                         )
@@ -218,7 +225,8 @@ class FilteredSpanClassification(ModuleBase):
             span_splitter: ModuleBase
                 Span splitter that returns List[Span]
             classifier: ModuleBase
-                Classification model instance returning Classification or TokenClassification output on .run
+                Classification model instance returning Classification or
+                TokenClassification output on .run
             default_threshold: float
                 Default threshold for scores
             labels_to_output: List[str]

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -17,7 +17,7 @@ classifications can be filtered by score threshold and label(s).
 At this time this module is only designed for inference"""
 
 # Standard
-from typing import List, Optional
+from typing import Iterable, List, Optional
 import os
 
 # First Party
@@ -32,9 +32,14 @@ from caikit.core.toolkit import error_handler
 import alog
 
 # Local
-from ...data_model import TokenClassification, TokenClassificationResult
+from ...data_model import (
+    StreamingTokenClassificationResult,
+    TokenClassification,
+    TokenClassificationResult,
+)
 from ..text_classification.text_classification_task import TextClassificationTask
 from .token_classification_task import TokenClassificationTask
+from caikit_nlp.modules.tokenization.tokenization_task import TokenizationTask
 
 log = alog.use_channel("FILT_SPAN")
 error = error_handler.get(log)
@@ -68,7 +73,7 @@ class FilteredSpanClassification(ModuleBase):
             lang: str
                 2 letter language code
             span_splitter: ModuleBase
-                Span splitter that returns List[Span]
+                Span splitter that returns TokenizationResult
             classifier: ModuleBase
                 Classification model instance returning Classification or
                 TokenClassification output on .run
@@ -80,6 +85,11 @@ class FilteredSpanClassification(ModuleBase):
         super().__init__()
         error.type_check("<NLP12578168E>", str, lang=lang)
         error.type_check("<NLP79642537E>", ModuleBase, span_splitter=span_splitter)
+        if span_splitter.TASK_CLASS is not TokenizationTask:
+            log.error(
+                "<NLP16242068E>",
+                "span_splitter does not implement TokenizationTask",
+            )
         error.type_check(
             "<NLP35742128E>",
             ModuleBase,
@@ -162,27 +172,57 @@ class FilteredSpanClassification(ModuleBase):
                         token_classification_results.append(token_classification)
         return TokenClassificationResult(results=token_classification_results)
 
-    def run_bidi_stream(self, text_stream, threshold: Optional[float] = None):
-        """Function to provide bi-directional streaming inferencing for this module"""
+    def run_bidi_stream(
+        self, text_stream: Iterable[str], threshold: Optional[float] = None
+    ) -> Iterable[StreamingTokenClassificationResult]:
+        """Run bi-directional streaming inferencing for this module.
+        Run classification on text split into spans. Returns results
+        based on score threshold for labels that are to be outputted
 
+        Args:
+            text_stream: Iterable[str]
+                Text stream to run classification on
+            threshold: float
+                (Optional) Threshold based on which to return score results
+
+        Returns:
+            Iterable[StreamingTokenClassificationResult]
+        """
         # TODO: For optimization implement window based approach.
+        if threshold is None:
+            threshold = self.default_threshold
 
+        offset = 0
         for span_output in self._stream_span_output(text_stream):
+            text_len = span_output.end - span_output.start
             classification_result = self.classifier.run(span_output.text)
             for classification in classification_result.results:
-                label = classification.label
-                # TODO: Figure out how we want to handle thresholding for streaming
-                # since with streaming, if the sentence we are processing
-                # is below threshold, do we want to skip yielding that response and try to get
-                # another one ? What if none cross / passes threshold.
-                yield TokenClassification(
-                    start=span_output.start,
-                    end=span_output.end,
-                    word=span_output.text,
-                    entity=label,
-                    score=classification.score,
-                )
-                # TODO: What would be final output DM for streaming.
+                # TODO: refactor common code between .run and here
+                if self.classification_task == TextClassificationTask:
+                    label = classification.label
+                    start = span_output.start
+                    end = span_output.end
+                    word = span_output.text
+                else:
+                    label = classification.entity
+                    start = classification.start
+                    end = classification.end
+                    word = classification.word
+                if classification.score >= threshold:
+                    if not self.labels_to_output or (
+                        self.labels_to_output and label in self.labels_to_output
+                    ):
+                        # TODO: update output DM
+                        # Need to add offset to track actual place of spans within a stream,
+                        # as the span splitting will be expected to stream and detect spans
+                        yield TokenClassification(
+                            start=start + offset,
+                            end=end + offset,
+                            word=word,
+                            entity=label,
+                            score=classification.score,
+                        )
+            offset += text_len
 
     def save(self, model_path: str):
         """Save model in target path
@@ -245,7 +285,7 @@ class FilteredSpanClassification(ModuleBase):
             lang: str
                 2 letter language code
             span_splitter: ModuleBase
-                Span splitter that returns List[Span]
+                Span splitter that returns TokenizationResult
             classifier: ModuleBase
                 Classification model instance returning Classification or
                 TokenClassification output on .run
@@ -263,7 +303,7 @@ class FilteredSpanClassification(ModuleBase):
             labels_to_output=labels_to_output,
         )
 
-    ################################## private functions #############################################
+    ################################## Private functions ##########################################
 
     def _stream_span_output(self, text_stream):
         """Function to yield span output from input text stream"""

--- a/caikit_nlp/modules/token_classification/filtered_span_classification.py
+++ b/caikit_nlp/modules/token_classification/filtered_span_classification.py
@@ -85,11 +85,11 @@ class FilteredSpanClassification(ModuleBase):
         super().__init__()
         error.type_check("<NLP12578168E>", str, lang=lang)
         error.type_check("<NLP79642537E>", ModuleBase, tokenizer=tokenizer)
-        if tokenizer.TASK_CLASS is not TokenizationTask:
-            log.error(
-                "<NLP16242068E>",
-                "tokenizer does not implement TokenizationTask",
-            )
+        error.value_check(
+            "<NLP42736791E>",
+            tokenizer.TASK_CLASS == TokenizationTask,
+            "tokenizer does not implement TokenizationTask",
+        )
         error.type_check(
             "<NLP35742128E>",
             ModuleBase,
@@ -100,11 +100,11 @@ class FilteredSpanClassification(ModuleBase):
             "<NLP71653678E>", str, allow_none=True, labels_to_output=labels_to_output
         )
         classification_task = classifier.TASK_CLASS
-        if classification_task not in ALLOWED_TASKS:
-            log.error(
-                "<NLP92989564E>",
-                f"classifier does not implement one of required tasks: {ALLOWED_TASKS}",
-            )
+        error.value_check(
+            "<NLP41319814E>",
+            classification_task in ALLOWED_TASKS,
+            f"classifier does not implement one of required tasks: {ALLOWED_TASKS}",
+        )
         self.lang = lang
         self.tokenizer = tokenizer
         self.classifier = classifier
@@ -194,7 +194,6 @@ class FilteredSpanClassification(ModuleBase):
 
         offset = 0
         for span_output in self._stream_span_output(text_stream):
-            text_len = span_output.end - span_output.start
             classification_result = self.classifier.run(span_output.text)
             for classification in classification_result.results:
                 # TODO: refactor common code between .run and here
@@ -222,7 +221,8 @@ class FilteredSpanClassification(ModuleBase):
                             entity=label,
                             score=classification.score,
                         )
-            offset += text_len
+            # The implication here is the span start is always 0
+            offset += span_output.end
 
     def save(self, model_path: str):
         """Save model in target path

--- a/caikit_nlp/modules/tokenization/regex_sentence_splitter.py
+++ b/caikit_nlp/modules/tokenization/regex_sentence_splitter.py
@@ -31,11 +31,12 @@ error = error_handler.get(log)
 
 @module(
     id="1e04e21b-7009-499e-abdd-41e5984c2e7d",
-    name="Sentence Splitter",
+    name="Regex Sentence Splitter",
     version="0.1.0",
     task=TokenizationTask,
 )
 class RegexSentenceSplitter(ModuleBase):
+    # pylint: disable=anomalous-backslash-in-string
     """Use python regexes to split document into sentences.
 
     Sample regex string:
@@ -52,6 +53,7 @@ class RegexSentenceSplitter(ModuleBase):
                 String containing pattern that can be complied with python re
                 module
         """
+        super().__init__()
         error.type_check("<NLP48846517E>", str, regex_str=regex_str)
         self.regex = re.compile(regex_str)
 

--- a/tests/modules/token_classification/test_filtered_span_classification.py
+++ b/tests/modules/token_classification/test_filtered_span_classification.py
@@ -24,6 +24,7 @@ from caikit_nlp.modules.token_classification import (
     FilteredSpanClassification,
     TokenClassificationTask,
 )
+from caikit_nlp.modules.tokenization.tokenization_task import TokenizationTask
 from tests.fixtures import SEQ_CLASS_MODEL
 
 ## Setup ########################################################################
@@ -36,9 +37,14 @@ DOCUMENT = (
 )
 
 # Span/sentence splitter for tests
-@module("4c9387f9-3683-4a94-bed9-8ecc1bf3ce47", "FakeTestSentenceSplitter", "0.0.1")
+@module(
+    "4c9387f9-3683-4a94-bed9-8ecc1bf3ce47",
+    "FakeTestSentenceSplitter",
+    "0.0.1",
+    task=TokenizationTask,
+)
 class FakeTestSentenceSplitter(ModuleBase):
-    def run(self, text: str):
+    def run(self, text: str) -> TokenizationResult:
         return TokenizationResult(
             results=[
                 Token(

--- a/tests/modules/token_classification/test_filtered_span_classification.py
+++ b/tests/modules/token_classification/test_filtered_span_classification.py
@@ -62,7 +62,7 @@ def test_bootstrap_run():
     model = FilteredSpanClassification.bootstrap(
         lang="en",
         span_splitter=SENTENCE_SPLITTER,
-        sequence_classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
+        classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
         default_threshold=0.5,
     )
     token_classification_result = model.run(DOCUMENT)
@@ -83,7 +83,7 @@ def test_bootstrap_run_with_threshold():
     model = FilteredSpanClassification.bootstrap(
         lang="en",
         span_splitter=SENTENCE_SPLITTER,
-        sequence_classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
+        classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
         default_threshold=0.5,
     )
     token_classification_result = model.run(DOCUMENT, threshold=0.0)
@@ -98,7 +98,7 @@ def test_bootstrap_run_with_optional_labels_to_output():
     model = FilteredSpanClassification.bootstrap(
         lang="en",
         span_splitter=SENTENCE_SPLITTER,
-        sequence_classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
+        classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
         default_threshold=0.5,
         labels_to_output=["LABEL_0"],
     )
@@ -118,7 +118,7 @@ def test_save_load_and_run_model():
     model = FilteredSpanClassification.bootstrap(
         lang="en",
         span_splitter=SENTENCE_SPLITTER,
-        sequence_classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
+        classifier=BOOTSTRAPPED_SEQ_CLASS_MODEL,
         default_threshold=0.5,
     )
     with tempfile.TemporaryDirectory() as model_dir:

--- a/tests/modules/token_classification/test_filtered_span_classification.py
+++ b/tests/modules/token_classification/test_filtered_span_classification.py
@@ -1,6 +1,7 @@
 """Tests for filtered span classification module
 """
 # Standard
+from typing import List
 import os
 import tempfile
 
@@ -18,7 +19,10 @@ from caikit_nlp.data_model.classification import (
 )
 from caikit_nlp.data_model.text import Span
 from caikit_nlp.modules.text_classification import SequenceClassification
-from caikit_nlp.modules.token_classification import FilteredSpanClassification
+from caikit_nlp.modules.token_classification import (
+    FilteredSpanClassification,
+    TokenClassificationTask,
+)
 from tests.fixtures import SEQ_CLASS_MODEL
 
 ## Setup ########################################################################
@@ -53,6 +57,41 @@ class FakeTestSentenceSplitter(ModuleBase):
 
 
 SENTENCE_SPLITTER = FakeTestSentenceSplitter()
+
+# Module that already returns token classification for tests
+@module(
+    "44d61711-c64b-4774-a39f-a9f40f1fcff0",
+    "FakeTokenClassificationModule",
+    "0.0.1",
+    task=TokenClassificationTask,
+)
+class FakeTokenClassificationModule(ModuleBase):
+    def run(self, text: str) -> TokenClassificationResult:
+        pass
+
+    def run_batch(self, texts: List[str]) -> List[TokenClassificationResult]:
+        return [
+            TokenClassificationResult(
+                results=[
+                    TokenClassification(
+                        start=7, end=12, word="goose", entity="animal", score=0.3
+                    ),
+                    TokenClassification(
+                        start=0, end=5, word="moose", entity="animal", score=0.8
+                    ),
+                ]
+            ),
+            TokenClassificationResult(
+                results=[
+                    TokenClassification(
+                        start=0, end=4, word="iris", entity="plant", score=0.7
+                    )
+                ]
+            ),
+        ]
+
+
+TOKEN_CLASSIFICATION_MODULE = FakeTokenClassificationModule()
 
 ## Tests ########################################################################
 
@@ -111,6 +150,26 @@ def test_bootstrap_run_with_optional_labels_to_output():
     assert first_result.word == "The quick brown fox jumps over the lazy dog."
     assert first_result.entity == "LABEL_0"
     assert approx(first_result.score) == 0.49526197
+
+
+def test_bootstrap_run_with_token_classification():
+    """Check if we can run span classification models with classifier that does token classification"""
+    model = FilteredSpanClassification.bootstrap(
+        lang="en",
+        span_splitter=SENTENCE_SPLITTER,
+        classifier=TOKEN_CLASSIFICATION_MODULE,
+        default_threshold=0.5,
+    )
+    token_classification_result = model.run(DOCUMENT)
+    assert isinstance(token_classification_result, TokenClassificationResult)
+    assert len(token_classification_result.results) == 2  # 2 results over 0.5 expected
+    assert isinstance(token_classification_result.results[0], TokenClassification)
+    first_result = token_classification_result.results[0]
+    assert first_result.start == 0
+    assert first_result.end == 5
+    assert first_result.word == "moose"
+    assert first_result.entity == "animal"
+    assert first_result.score == 0.8
 
 
 def test_save_load_and_run_model():


### PR DESCRIPTION
 - Generalize the "sequence classifier" for filtered span classification to work for classifiers that do either token classification or text classification
 - Add new DM for streaming filtered span classification (not used yet)
 - Make streaming filtered span classification "functional" with threshold